### PR TITLE
Switch configuration to us-east-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Este repositório contém a infraestrutura como código (**IaC**) para provision
 - Atualizações automáticas
 - Integração com Route53 para DNS dinâmico
 
-A infraestrutura é criada usando **Terraform** na região **`sa-east-1` (São Paulo)** da AWS.
+A infraestrutura é criada usando **Terraform** na região **`us-east-1` (N. Virginia)** da AWS.
 
 ---
 
@@ -213,6 +213,9 @@ cd app-o8partners-terraform
 key_name           = "seu-par-de-chaves"
 allowed_cidr       = "seu-ip-publico/32"
 route53_zone_id    = "Z0XXXXXXXXXXXXXX"
+aws_region         = "us-east-1"
+subnet_id          = "subnet-abcdefgh"
+security_group_ids = ["sg-12345678"]
 ```
 
 > Substitua pelos valores reais antes de executar o Terraform.

--- a/install_openvpn.md
+++ b/install_openvpn.md
@@ -10,7 +10,7 @@ Este script automatiza a instalação e configuração completa de um **servidor
 - Atualizações automáticas
 - Serviço Nginx para download do cliente `.ovpn`
 
-O script é otimizado para execução em **Ubuntu Server** na região **sa-east-1 (São Paulo)** da AWS.
+O script é otimizado para execução em **Ubuntu Server** na região **us-east-1 (N. Virginia)** da AWS.
 
 ---
 

--- a/main.tf
+++ b/main.tf
@@ -6,4 +6,6 @@ module "ec2" {
   admin_user       = var.admin_user
   ovpn_password    = var.ovpn_password
   api_token        = var.api_token
+  subnet_id        = var.subnet_id
+  security_group_ids = var.security_group_ids
 }

--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -1,8 +1,8 @@
 resource "aws_instance" "vpn_instance" {
   ami                    = data.aws_ami.ubuntu.id
   instance_type          = "t4g.medium"
-  subnet_id              = aws_subnet.public_subnet.id
-  vpc_security_group_ids = [aws_security_group.vpn_sg.id]
+  subnet_id              = var.subnet_id
+  vpc_security_group_ids = var.security_group_ids
   key_name               = var.key_name
   ena_support            = true
   ebs_optimized          = true
@@ -26,12 +26,3 @@ resource "aws_instance" "vpn_instance" {
   ]
 }
 
-module "ec2" {
-  source         = "./modules/ec2"
-  key_name       = var.key_name
-  allowed_cidr   = var.allowed_cidr
-  route53_zone_id = var.route53_zone_id
-  admin_user     = var.admin_user
-  ovpn_password  = var.ovpn_password
-  api_token      = var.api_token
-}

--- a/modules/ec2/variables.tf
+++ b/modules/ec2/variables.tf
@@ -9,6 +9,16 @@ variable "allowed_cidr" {
   type        = string
 }
 
+variable "subnet_id" {
+  description = "ID da subnet onde a instância será provisionada"
+  type        = string
+}
+
+variable "security_group_ids" {
+  description = "Lista de Security Groups a serem associados à instância"
+  type        = list(string)
+}
+
 variable "route53_zone_id" {
   description = "ID da zona DNS no Route53 onde os registros serão criados"
   type        = string

--- a/providers.tf
+++ b/providers.tf
@@ -1,4 +1,4 @@
 provider "aws" {
-  region = "sa-east-1"
+  region  = var.aws_region
   # profile = "default" # Descomente se usar um profile específico
-} 
+}

--- a/terraform.tfvars 
+++ b/terraform.tfvars 
@@ -3,6 +3,9 @@
 key_name        = "sua-chave-aws"
 allowed_cidr    = "seu-ip-publico/32"
 route53_zone_id = "Z0XXXXXXXXXXXXXX"
+aws_region      = "us-east-1"
+subnet_id       = "subnet-abcdefgh"
+security_group_ids = ["sg-12345678"]
 
 # Opcional: substituir defaults
 admin_user      = "admin"

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,22 @@
+variable "aws_region" {
+  description = "Região AWS onde os recursos serão criados"
+  type        = string
+  default     = "us-east-1"
+}
+
 variable "key_name" {
   description = "Nome do par de chaves SSH cadastrado na AWS"
   type        = string
+}
+
+variable "subnet_id" {
+  description = "ID da subnet na VPC a ser utilizada"
+  type        = string
+}
+
+variable "security_group_ids" {
+  description = "Lista de Security Groups para a instância"
+  type        = list(string)
 }
 
 variable "allowed_cidr" {


### PR DESCRIPTION
## Summary
- configure AWS provider using `aws_region` variable
- document and add default variables for region, subnet, and security groups
- update examples in README for new region and variables
- set N. Virginia region in docs
- wire new variables into EC2 module

## Testing
- `terraform init -backend=false` *(fails: could not reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_6859d27f77fc832d9aa781d071143210